### PR TITLE
bug: Allow svg in partial without passing "site: site" explicitly

### DIFF
--- a/lib/bridgetown-inline-svg/svg-tag.rb
+++ b/lib/bridgetown-inline-svg/svg-tag.rb
@@ -74,7 +74,7 @@ module BridgetownInlineSvg
       matched = markup.strip.match(PATH_SYNTAX)
       unless matched
         raise SyntaxError, <<~END
-          Syntax Error in tag 'highlight' while parsing the following markup:
+          Syntax Error in tag 'svg' while parsing the following markup:
           #{markup}
           Valid syntax: svg <path> [property=value]
         END
@@ -119,6 +119,7 @@ module BridgetownInlineSvg
       # check if given name is a variable. Otherwise use it as a file name
       svg_file = Bridgetown.sanitized_path(site.source, interpolate(@svg, context))
       return unless svg_file
+
       add_file_to_dependency(site, svg_file, context)
       # replace variables with their current value
       params = split_params(@params, context)
@@ -128,15 +129,16 @@ module BridgetownInlineSvg
       end
       # params = @params
       file = File.open(svg_file, "rb").read
-      conf = lookup_variable(context, "site.svg")
+
+      conf = site.config['svg'] || {}
+
       if conf["optimize"] == true
-        xml = SvgOptimizer.optimize(file, [create_plugin(params)] + PLUGINS)
+        SvgOptimizer.optimize(file, [create_plugin(params)] + PLUGINS)
       else
         xml = Nokogiri::XML(file)
         params.each { |key, val| xml.root.set_attribute(key, val) }
-        xml = xml.root.to_xml
+        xml.root.to_xml
       end
-      xml
     end
   end
 end

--- a/lib/bridgetown-inline-svg/svg-tag.rb
+++ b/lib/bridgetown-inline-svg/svg-tag.rb
@@ -130,7 +130,7 @@ module BridgetownInlineSvg
       # params = @params
       file = File.open(svg_file, "rb").read
 
-      conf = site.config['svg'] || {}
+      conf = site.config["svg"] || {}
 
       if conf["optimize"] == true
         SvgOptimizer.optimize(file, [create_plugin(params)] + PLUGINS)

--- a/spec/fixtures/src/_components/navbar.liquid
+++ b/spec/fixtures/src/_components/navbar.liquid
@@ -1,0 +1,3 @@
+<div id="component">
+  {% svg images/square.svg width: 100 height: 100 %}
+</div>

--- a/spec/fixtures/src/_components/partial.liquid
+++ b/spec/fixtures/src/_components/partial.liquid
@@ -1,3 +1,3 @@
-<div id="component-navbar">
+<div id="component-partial">
   {% svg images/square.svg width="100" height="100" %}
 </div>

--- a/spec/fixtures/src/_layouts/default.html
+++ b/spec/fixtures/src/_layouts/default.html
@@ -6,5 +6,11 @@
   <body>
     THIS IS MY LAYOUT
     {{ content }}
+
+    {% render "navbar" site: site %}
+
+    <div id="layout">
+      {% svg images/square.svg width: 100 height: 100 %}
+    </div>
   </body>
 </html>

--- a/spec/fixtures/src/index.html
+++ b/spec/fixtures/src/index.html
@@ -40,3 +40,5 @@ svgclass: hello
 <div id="optimize">
   {% svg /images/{{page.svgname}}.svg data-foo="" %}
 </div>
+
+{% render "partial" %}


### PR DESCRIPTION
I noticed while building my site that if I had `{% svg /images/image.svg %}` within an component file ( `_components/navbar.liquid` ) & I didn't explicitly pass `site: site` when adding the partial, I'd see a build error. For example:

```html
# _components/navbar.liquid
{% svg /images/image.svg %}

# index.html
{% render "navbar" site: site %} - Would be fine
{% render "navbar" %} - Will error
```

## What is the purpose of this pull request?

This aims to not make passing site being required. It's not a _right_ solution I think, but I did add to the test suite to reproduce the error.

## What changes did you make? (overview)

I removed `lookup_variable`, instead looking up directly from `site.config['svg']`. It does mean when site isn't passed to the context, it'll not find the config.

## Is there anything you'd like reviewers to focus on?

This isn't the best solution, is there a way we can get the current sites configuration? Either way, I just wanted to get the PR in :)

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
